### PR TITLE
feat: Catche Webhook entry with configuration

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -36,7 +36,7 @@ var (
 		Use:   "serve",
 		Short: "serve the http server",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := config.Validate(); err != nil {
+			if err := config.Load(); err != nil {
 				log.Fatal().Err(err).Msg("invalid configuration")
 			}
 

--- a/config/webhooks.example.yml
+++ b/config/webhooks.example.yml
@@ -1,7 +1,7 @@
 apiVersion: v1alplha1
 specs:
-  exampleHook:
-    entrypointUrl: /webhooks/example
-    security:
-      headerCheck:
-        value: 'very-secret-value'
+- name: exampleHook
+  entrypointUrl: /webhooks/example
+  security:
+    headerCheck:
+      value: 'very-secret-value'

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -2,30 +2,49 @@ package config
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 )
 
 var (
-	config = &Configuration{}
+	currentConfig = &Configuration{}
 	// ErrSpecNotFound is returned when the spec is not found
 	ErrSpecNotFound = errors.New("spec not found")
 )
 
-/**
- * Validate the configuration file and her content
- */
-func Validate() error {
-	err := viper.Unmarshal(&config)
+func Load() error {
+	err := viper.Unmarshal(&currentConfig)
 	if err != nil {
 		return err
 	}
 
-	// TODO Validation of the configuration if necessary
-	// for name, spec := range config.Specs {
-	// 	log.Debug().Str("name", name).Msgf("Load spec: %+v", spec)
-	// }
+	return Validate(currentConfig)
+}
+
+/**
+ * Validate the configuration file and her content
+ */
+func Validate(config *Configuration) error {
+	var uniquenessName = make(map[string]bool)
+	var uniquenessUrl = make(map[string]bool)
+
+	for _, spec := range config.Specs {
+		log.Debug().Str("name", spec.Name).Msgf("Load spec: %+v", spec)
+
+		// Validate the uniqueness of all name
+		if _, ok := uniquenessName[spec.Name]; ok {
+			return fmt.Errorf("name %s is not unique", spec.Name)
+		}
+		uniquenessName[spec.Name] = true
+
+		// Validate the uniqueness of all entrypoints
+		if _, ok := uniquenessUrl[spec.EntrypointURL]; ok {
+			return fmt.Errorf("entrypointUrl %s is not unique", spec.EntrypointURL)
+		}
+		uniquenessUrl[spec.EntrypointURL] = true
+	}
 
 	log.Debug().Msgf("Load %d configurations", len(config.Specs))
 	return nil
@@ -33,19 +52,21 @@ func Validate() error {
 
 // Current returns the aftual configuration
 func Current() *Configuration {
-	return config
+	return currentConfig
 }
 
 // GetSpec returns the spec for the given name, if no entry
 // is found, ErrSpecNotFound is returned
 func (c *Configuration) GetSpec(name string) (*WebhookSpec, error) {
-	spec, ok := c.Specs[name]
-	if !ok {
-		log.Error().Err(ErrSpecNotFound).Msgf("Spec %s not found", name)
-		return nil, ErrSpecNotFound
+	for _, spec := range c.Specs {
+		if spec.Name == name {
+			return spec, nil
+		}
 	}
 
-	return &spec, nil
+	log.Error().Err(ErrSpecNotFound).Msgf("Spec %s not found", name)
+	return nil, ErrSpecNotFound
+
 }
 
 // GetSpecByEndpoint returns the spec for the given endpoint, if no entry
@@ -54,7 +75,7 @@ func (c *Configuration) GetSpecByEndpoint(endpoint string) (*WebhookSpec, error)
 	for _, spec := range c.Specs {
 		if spec.EntrypointURL == endpoint {
 			log.Warn().Msgf("No spec found for %s endpoint", endpoint)
-			return &spec, nil
+			return spec, nil
 		}
 	}
 

--- a/internal/config/structs.go
+++ b/internal/config/structs.go
@@ -1,11 +1,12 @@
 package config
 
 type Configuration struct {
-	APIVersion string                 `mapstructure:"apiVersion"`
-	Specs      map[string]WebhookSpec `mapstructure:"specs"`
+	APIVersion string         `mapstructure:"apiVersion"`
+	Specs      []*WebhookSpec `mapstructure:"specs"`
 }
 
 type WebhookSpec struct {
+	Name          string                  `mapstructure:"name"`
 	EntrypointURL string                  `mapstructure:"entrypointUrl"`
 	Security      map[string]SecuritySpec `mapstructure:"security"`
 	Storage       map[string]StorageSpec  `mapstructure:"storage"`

--- a/internal/server/v1alpha1/handlers.go
+++ b/internal/server/v1alpha1/handlers.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	"42stellar.org/webhooks/internal/config"
@@ -11,14 +12,18 @@ import (
 
 type Server struct {
 	config         *config.Configuration
-	webhookService func(spec *config.WebhookSpec) error
+	webhookService func(s *Server, spec *config.WebhookSpec) error
+	logger         zerolog.Logger
 }
 
 func NewServer() *Server {
-	return &Server{
+	var s = &Server{
 		config:         config.Current(),
 		webhookService: webhookService,
 	}
+
+	s.logger = log.With().Str("apiVersion", s.Version()).Logger()
+	return s
 }
 
 func (s *Server) Version() string {
@@ -28,7 +33,7 @@ func (s *Server) Version() string {
 func (s *Server) WebhookHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if s.config.APIVersion != s.Version() {
-			log.Error().Str("apiVersion", s.Version()).Msg("Configuration don't match with the API version")
+			s.logger.Error().Msg("Configuration don't match with the API version")
 			w.WriteHeader(http.StatusBadRequest)
 		}
 
@@ -38,24 +43,26 @@ func (s *Server) WebhookHandler() http.HandlerFunc {
 			return
 		}
 
-		if err := s.webhookService(spec); err != nil {
-			log.Error().Err(err).Msg("Error while processing webhook")
+		if err := s.webhookService(s, spec); err != nil {
+			s.logger.Error().Err(err).Msg("Error while processing webhook")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 	}
 }
 
-func webhookService(spec *config.WebhookSpec) error {
+func webhookService(s *Server, spec *config.WebhookSpec) error {
 	if spec == nil {
 		return config.ErrSpecNotFound
 	}
+	defer s.logger.Debug().Str("entry", spec.Name).Msg("Webhook processed")
 
 	if spec.HasSecurity() {
 		// TODO Do security Layer
-		log.Warn().Msg("Security layer not implemented yet")
+		s.logger.Warn().Msg("Security layer not implemented yet")
 	}
 
 	// TODO Do the webhook storage
+	s.logger.Warn().Msg("Storage not implemented yet")
 	return nil
 }

--- a/internal/server/v1alpha1/handlers_test.go
+++ b/internal/server/v1alpha1/handlers_test.go
@@ -40,12 +40,13 @@ func TestServer_WebhookHandler(t *testing.T) {
 		testServer_WebhookHandler_Helper(t, &Server{
 			config: &config.Configuration{
 				APIVersion: "v1alpha1",
-				Specs: map[string]config.WebhookSpec{
-					"test": {
+				Specs: []*config.WebhookSpec{
+					{
+						Name:          "test",
 						EntrypointURL: "/test",
 					}},
 			},
-			webhookService: func(spec *config.WebhookSpec) error { return expectedError },
+			webhookService: func(s *Server, spec *config.WebhookSpec) error { return expectedError },
 		}).Code,
 	)
 
@@ -54,12 +55,13 @@ func TestServer_WebhookHandler(t *testing.T) {
 		testServer_WebhookHandler_Helper(t, &Server{
 			config: &config.Configuration{
 				APIVersion: "v1alpha1",
-				Specs: map[string]config.WebhookSpec{
-					"test": {
+				Specs: []*config.WebhookSpec{
+					{
+						Name:          "test",
 						EntrypointURL: "/test",
 					}},
 			},
-			webhookService: func(spec *config.WebhookSpec) error { return nil },
+			webhookService: func(s *Server, spec *config.WebhookSpec) error { return nil },
 		}).Code,
 	)
 }
@@ -100,6 +102,6 @@ func Test_webhookService(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(webhookService(test.input), test.expected, "input: %d", test.input)
+		assert.Equal(webhookService(&Server{}, test.input), test.expected, "input: %d", test.input)
 	}
 }


### PR DESCRIPTION
**Relative Issues:** #1 

**Describe the pull request**
We needs to get the spec name properly to perform action correctly. I have rewrite configuration section to have `name` field instead of `map[string]struct{}`. With this breaking changes, I have update all tests and code.

I also add the configuration validation for Endpoint and Name uniqueness

**Checklist**

- [x] I have linked the relative issue to this pull request
- [x] I have made the modifications or added tests related to my PR
- [x] I have added/updated the documentation for my RP
- [x] I put my PR in Ready for Review only when all the checklist is checked

**Breaking changes ?**
yes

**Additional context**
Add any other context about your PR here.
